### PR TITLE
[Build] Make it work on Linux

### DIFF
--- a/include/valijson/adapters/nlohmann_json_adapter.hpp
+++ b/include/valijson/adapters/nlohmann_json_adapter.hpp
@@ -553,14 +553,7 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-    opt::optional<NlohmannJsonObject> getObjectOptional() const
-    {
-        if (m_value.is_object()) {
-            return opt::make_optional(NlohmannJsonObject(m_value));
-        }
-
-        return {};
-    }
+    opt::optional<NlohmannJsonObject> getObjectOptional() const;
 
     /**
      * @brief   Retrieve the number of members in the object
@@ -678,6 +671,17 @@ public:
     {
     }
 };
+
+template <class ValueType>
+opt::optional<NlohmannJsonObject>
+NlohmannJsonValue<ValueType>::getObjectOptional() const
+{
+    if (m_value.is_object()) {
+        return opt::make_optional(NlohmannJsonObject(m_value));
+    }
+
+    return {};
+}
 
 /// Specialisation of the AdapterTraits template struct for NlohmannJsonAdapter.
 template<>


### PR DESCRIPTION
We need to separate the decl & definition, or we get this compilation error on Linux.

```
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/stl_pair.h:215:11: error: field has incomplete type 'valijson::adapters::NlohmannJsonAdapter'
      _T2 second;                /// @c second is a copy of the second object
          ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/type_traits:884:32: note: in instantiation of template class 'std::pair<std::basic_string<char>, valijson::adapters::NlohmannJsonAdapter>' requested here
      : public __bool_constant<__is_constructible(_Tp, _Args...)>
                               ^
/home/yekuang/Github/taco/third_party/nlohmann_json/single_include/nlohmann/json.hpp:3406:27: note: in instantiation of template class 'std::is_constructible<nlohmann::basic_json<>, std::pair<std::basic_string<char>, valijson::adapters::NlohmannJsonAdapter>>' requested here
struct is_constructible : std::is_constructible<T, Args...> {};
                          ^
/home/yekuang/Github/taco/third_party/nlohmann_json/single_include/nlohmann/json.hpp:3567:9: note: in instantiation of template class 'nlohmann::detail::is_constructible<nlohmann::basic_json<>, std::pair<std::basic_string<char>, valijson::adapters::NlohmannJsonAdapter>>' requested here
        is_constructible<BasicJsonType,
        ^
/home/yekuang/Github/taco/third_party/nlohmann_json/single_include/nlohmann/json.hpp:5211:48: note: in instantiation of static data member 'nlohmann::detail::is_compatible_array_type_impl<nlohmann::basic_json<>, valijson::adapters::NlohmannJsonObject>::value' requested here
                         CompatibleArrayType>::value&&
                                               ^
/home/yekuang/Github/taco/third_party/nlohmann_json/single_include/nlohmann/json.hpp:5217:13: note: while substituting prior template arguments into non-type template parameter [with BasicJsonType = nlohmann::basic_json<>, CompatibleArrayType = valijson::adapters::NlohmannJsonObject]
inline void to_json(BasicJsonType& j, const CompatibleArrayType& arr)
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/yekuang/Github/taco/third_party/nlohmann_json/single_include/nlohmann/json.hpp:5302:17: note: (skipping 12 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
    -> decltype(to_json(j, std::forward<T>(val)), void())
                ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/type_traits:1158:14: note: in instantiation of template class 'std::__is_trivially_copy_constructible_impl<valijson::adapters::NlohmannJsonObject, true>' requested here
    : public __is_trivially_copy_constructible_impl<_Tp>
             ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/type_traits:2939:5: note: in instantiation of template class 'std::is_trivially_copy_constructible<valijson::adapters::NlohmannJsonObject>' requested here
    is_trivially_copy_constructible<_Tp>::value;
    ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/optional:469:12: note: in instantiation of variable template specialization 'std::is_trivially_copy_constructible_v<valijson::adapters::NlohmannJsonObject>' requested here
           bool = is_trivially_copy_constructible_v<_Tp>,
                  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/optional:657:15: note: in instantiation of default argument for '_Optional_base<valijson::adapters::NlohmannJsonObject>' required here
    : private _Optional_base<_Tp>,
              ^~~~~~~~~~~~~~~~~~~
/home/yekuang/Github/taco/third_party/valijson/include/valijson/adapters/nlohmann_json_adapter.hpp:556:39: note: in instantiation of template class 'std::optional<valijson::adapters::NlohmannJsonObject>' requested here
    opt::optional<NlohmannJsonObject> getObjectOptional() const
                                      ^
/home/yekuang/Github/taco/third_party/valijson/include/valijson/adapters/nlohmann_json_adapter.hpp:40:7: note: forward declaration of 'valijson::adapters::NlohmannJsonAdapter'
class NlohmannJsonAdapter;
```